### PR TITLE
Updates to UI for torpedo calculation

### DIFF
--- a/content/scripts/screen_holomap.lua
+++ b/content/scripts/screen_holomap.lua
@@ -1023,10 +1023,14 @@ function _update(screen_w, screen_h, ticks)
             end
 
             update_ui_image(cx, cy, atlas_icons.column_angle, icon_col, 0)
-            update_ui_text(cx + 15, cy, string.format("%.0f deg", bearing_world), 100, 0, text_col, 0)
+            update_ui_text(cx + 15, cy, string.format("Bearing: %.0f deg", bearing_world), 100, 0, text_col, 0)
             cy = cy - 10
 
             local dist = vec2_dist(vec2(g_ruler_x, g_ruler_y), vec2(world_x, world_y))
+            
+            update_ui_image(cx, cy, atlas_icons.map_icon_loop, icon_col, 0)
+            update_ui_text(cx + 15, cy, string.format("Torpedo Delay: %.0f s", dist/50), 500, 0, text_col, 0)
+            cy = cy - 10
 
             if dist < 10000 then
                 update_ui_image(cx, cy, atlas_icons.column_distance, icon_col, 0)
@@ -1124,7 +1128,7 @@ function _update(screen_w, screen_h, ticks)
                 update_ui_text(screen_w / 9, screen_h - 24,
                         "Revolution Spectator Studio TM", 400, 0, color_grey_mid, 0)
             else
-                update_ui_text(screen_w / 8, screen_h - 31,
+                update_ui_text(screen_w / 4, screen_h - 31,
                         string.format("ACC %s",
                                 get_ship_name(update_get_screen_vehicle())), 400, 0, color_grey_mid, 0)
 


### PR DESCRIPTION
This is achieved by implementing the calculation provided on https://strategywiki.org/wiki/Carrier_Command_2/Carrier:_Offensive_Weapons 
(activation delay in seconds) = (desired arming distance from your carrier in meters) / 50 
The 50 m/s value is the torpedo speed - any change to the torpedo speed beyond vanilla will obviously impact this calculator.

The screen holomap UI code is updated to capture this calculation with some extra text.  
1. The carrier name display on holomap is offset more to the right 
2. Added new row to UI upon drawing lines on the holomap which adds text and the torpedo delay calculation 
3. Added string "bearing" to degree UI row

![image](https://github.com/user-attachments/assets/f5af8e17-42ad-45fb-8214-3336209fe2c6)
